### PR TITLE
feat: field-config + fieldValues schema (Recce overhaul)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ GRIP is storage-agnostic. Documents are identified by natural keys (rally name +
 
 ## Schemas
 
-### `pace-note.schema.json`
-A pace-note document covers one note set: a single stage, by a single driver, at a specific version. It carries a header (`rally`, `stage`, `set`), the per-rally chip vocabulary (`chips`), and the ordered list of calls (`notes`).
+### `field-config.schema.json`
+The per-rally definition of which pace-note fields exist. Each field carries a unique `key`, a `kind` (`chips` | `freetext` | `number`), grid placement (`col`, `row`, `w`, `h`), render/TTS order, and — for chips-kind fields — an inline vocabulary of allowed values with their audibles and rendering hints. Replaces the previous fixed-field model so rallies can ship entirely different shorthand systems.
 
-Chips define the legal values each pace-note field may take. They also describe how each value should be rendered (`textFormat`), spoken (`audible`), and — for severity chips — placed on a compass dial (`angle`, in degrees).
+### `pace-note.schema.json`
+A pace-note document covers one note set: a single stage, at a specific version. It carries a header (`rally`, `stage`, `set`), an optional inlined `fieldConfig`, and the ordered list of calls (`notes`). Each note holds its position/meta at the top level and the actual shorthand values under `fieldValues` keyed by the field-config's field keys.
 
 ### `stage-geometry.schema.json`
 A stage-geometry document describes a stage as an ordered list of segments. Each segment carries the length, heading change, and surface/roadside shape for the **end** of the segment. The first segment should be length zero and is used to initialize the starting shape.
@@ -23,44 +24,59 @@ For loose surfaces (sand, snow): `depthCentimeters = 0` means packed underneath;
   "rally": { "name": "Rocky Mountain", "date": "2025-08-11" },
   "stage": { "name": "SS1" },
   "set":   { "version": 1, "driver": "A. Mouton", "recceDate": "2025-08-11" },
-  "chips": [
-    { "category": "direction", "value": "left",  "sortOrder": 0 },
-    { "category": "direction", "value": "right", "sortOrder": 1 },
-    { "category": "severity",  "value": "6", "sortOrder": 0, "angle": 12, "textFormat": ["sub"] },
-    { "category": "caution_decorator", "value": "!!", "sortOrder": 0 }
-  ],
+  "fieldConfig": {
+    "schemaVersion": 1,
+    "fields": [
+      {
+        "key": "direction", "label": "Direction", "kind": "chips",
+        "grid": { "col": 0, "row": 0, "w": 2, "h": 3 },
+        "renderOrder": 0, "ttsOrder": 0, "compact": true,
+        "chips": [
+          { "value": "L", "audible": "Left" },
+          { "value": "R", "audible": "Right" }
+        ]
+      },
+      {
+        "key": "severity", "label": "Severity", "kind": "chips",
+        "grid": { "col": 2, "row": 0, "w": 2, "h": 3 },
+        "renderOrder": 1, "ttsOrder": 1, "compact": true,
+        "chips": [
+          { "value": "6", "angle": 12, "textFormat": ["sub"] }
+        ]
+      },
+      {
+        "key": "link", "label": "Link", "kind": "chips",
+        "grid": { "col": 4, "row": 0, "w": 2, "h": 1 },
+        "renderOrder": 2, "ttsOrder": 2,
+        "numeric": { "min": 10, "max": 900, "step": 10 },
+        "chips": [
+          { "value": "tightens" }
+        ]
+      }
+    ]
+  },
   "notes": [
     {
       "seq": 12,
-      "indexOdo": null,
       "indexLandmark": null,
-      "indexSequence": 12,
-      "direction": "left",
-      "severity": "6",
-      "duration": "long",
-      "decorators": ["keep", "in"],
-      "joiner": "tightens",
-      "joinerDecorators": [],
-      "notes": null,
-      "joinerNotes": null,
-      "recceAt": "2025-08-11T15:30:00Z",
-      "updatedAt": "2025-08-11T15:30:00Z"
+      "fieldValues": {
+        "direction": "L",
+        "severity": "6",
+        "duration": "long",
+        "decorator": ["keep", "in"],
+        "link": "tightens"
+      },
+      "recceAt": "2025-08-11T15:30:00Z"
     },
     {
       "seq": 13,
-      "indexOdo": null,
       "indexLandmark": "red house",
-      "indexSequence": 13,
-      "direction": null,
-      "severity": null,
-      "duration": null,
-      "decorators": ["!!", "keep", "right", "over", "jump", "maybe"],
-      "joiner": "100",
-      "joinerDecorators": [],
-      "notes": null,
-      "joinerNotes": null,
-      "recceAt": "2025-08-11T15:30:00Z",
-      "updatedAt": "2025-08-11T15:30:00Z"
+      "fieldValues": {
+        "caution": ["!!"],
+        "decorator": ["keep", "right", "over", "jump", "maybe"],
+        "link": 100
+      },
+      "recceAt": "2025-08-11T15:30:00Z"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -12,10 +12,20 @@ The per-rally definition of which pace-note fields exist. Each field carries a u
 ### `pace-note.schema.json`
 A pace-note document covers one note set: a single stage, at a specific version. It carries a header (`rally`, `stage`, `set`), an optional inlined `fieldConfig`, and the ordered list of calls (`notes`). Each note holds its position/meta at the top level and the actual shorthand values under `fieldValues` keyed by the field-config's field keys.
 
+#### Producer / consumer contract
+- A producer must ensure every key used in `notes[].fieldValues` is declared in the rally's `fieldConfig.fields[].key`. Validators will not catch orphan keys — that's the producer's job.
+- When a pace-note document inlines its `fieldConfig`, that inlined copy is authoritative for the document. Consumers should render against it rather than against any cached or sibling configuration.
+- Consumers should treat unknown field keys as informational and skip them gracefully, to preserve forward compatibility as field-configs evolve.
+
 ### `stage-geometry.schema.json`
 A stage-geometry document describes a stage as an ordered list of segments. Each segment carries the length, heading change, and surface/roadside shape for the **end** of the segment. The first segment should be length zero and is used to initialize the starting shape.
 
 For loose surfaces (sand, snow): `depthCentimeters = 0` means packed underneath; a positive value is the depth of loose material on top.
+
+## Presets
+
+### `presets/classic-rally.field-config.json`
+A starter field-config that reproduces the historical eight-column pace-note vocabulary (`caution`, `direction`, `severity`, `duration`, `decorator`, `link`, `linkDecorator`, `notes`, `linkNotes`). Use it as-is by inlining it under `fieldConfig` in your pace-note documents, or fork it as the starting point for a rally with custom shorthand. Chip vocabularies are example starters — prune or extend per crew.
 
 ## Sample: pace notes
 
@@ -28,9 +38,18 @@ For loose surfaces (sand, snow): `depthCentimeters = 0` means packed underneath;
     "schemaVersion": 1,
     "fields": [
       {
+        "key": "caution", "label": "Caution", "kind": "chips",
+        "grid": { "col": 0, "row": 0, "w": 1, "h": 1 },
+        "renderOrder": 0, "ttsOrder": 0, "repeatable": true, "compact": true,
+        "chips": [
+          { "value": "!" },
+          { "value": "!!" }
+        ]
+      },
+      {
         "key": "direction", "label": "Direction", "kind": "chips",
-        "grid": { "col": 0, "row": 0, "w": 2, "h": 3 },
-        "renderOrder": 0, "ttsOrder": 0, "compact": true,
+        "grid": { "col": 0, "row": 1, "w": 2, "h": 3 },
+        "renderOrder": 1, "ttsOrder": 1, "compact": true,
         "chips": [
           { "value": "L", "audible": "Left" },
           { "value": "R", "audible": "Right" }
@@ -38,16 +57,25 @@ For loose surfaces (sand, snow): `depthCentimeters = 0` means packed underneath;
       },
       {
         "key": "severity", "label": "Severity", "kind": "chips",
-        "grid": { "col": 2, "row": 0, "w": 2, "h": 3 },
-        "renderOrder": 1, "ttsOrder": 1, "compact": true,
+        "grid": { "col": 2, "row": 1, "w": 2, "h": 3 },
+        "renderOrder": 2, "ttsOrder": 2, "compact": true,
         "chips": [
           { "value": "6", "angle": 12, "textFormat": ["sub"] }
         ]
       },
       {
+        "key": "duration", "label": "Duration", "kind": "chips",
+        "grid": { "col": 4, "row": 1, "w": 1, "h": 3 },
+        "renderOrder": 3, "ttsOrder": 3, "compact": true,
+        "chips": [
+          { "value": "long" },
+          { "value": "short" }
+        ]
+      },
+      {
         "key": "link", "label": "Link", "kind": "chips",
-        "grid": { "col": 4, "row": 0, "w": 2, "h": 1 },
-        "renderOrder": 2, "ttsOrder": 2,
+        "grid": { "col": 5, "row": 1, "w": 3, "h": 3 },
+        "renderOrder": 4, "ttsOrder": 4,
         "numeric": { "min": 10, "max": 900, "step": 10 },
         "chips": [
           { "value": "tightens" }
@@ -63,7 +91,6 @@ For loose surfaces (sand, snow): `depthCentimeters = 0` means packed underneath;
         "direction": "L",
         "severity": "6",
         "duration": "long",
-        "decorator": ["keep", "in"],
         "link": "tightens"
       },
       "recceAt": "2025-08-11T15:30:00Z"
@@ -73,7 +100,6 @@ For loose surfaces (sand, snow): `depthCentimeters = 0` means packed underneath;
       "indexLandmark": "red house",
       "fieldValues": {
         "caution": ["!!"],
-        "decorator": ["keep", "right", "over", "jump", "maybe"],
         "link": 100
       },
       "recceAt": "2025-08-11T15:30:00Z"

--- a/field-config.schema.json
+++ b/field-config.schema.json
@@ -1,0 +1,198 @@
+{
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "title": "GripFieldConfig",
+    "description": "Per-rally configuration of pace-note fields. Each rally defines which fields appear on a pacenote (name, kind, grid placement, render/TTS order, optional inline chip vocabulary). Pace notes then store their values as a JSON object keyed by field.key. Replaces the previous fixed-field model (direction / severity / duration / joiner / decorators / notes) so different rallies and disciplines can use entirely different shorthand systems.",
+    "type": "object",
+    "required": [
+        "schemaVersion",
+        "fields"
+    ],
+    "definitions": {
+        "field": {
+            "type": "object",
+            "description": "A single pace-note field. The combination of key + kind + grid determines where it lives, how it's input, and how it renders.",
+            "required": [
+                "key",
+                "kind"
+            ],
+            "properties": {
+                "key": {
+                    "type": "string",
+                    "pattern": "^[a-zA-Z0-9_]+$",
+                    "description": "Unique field identifier within the rally. Used as the property name under paceNote.fieldValues."
+                },
+                "label": {
+                    "type": "string",
+                    "description": "Display label shown on the canvas slot and pickers."
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "chips",
+                        "freetext",
+                        "number"
+                    ],
+                    "description": "How the field is entered. chips = pick from an inline vocabulary; freetext = type any string; number = numeric input (e.g. distance)."
+                },
+                "grid": {
+                    "type": "object",
+                    "description": "Placement on the rally's input grid. Origin top-left.",
+                    "required": [
+                        "col",
+                        "row",
+                        "w",
+                        "h"
+                    ],
+                    "properties": {
+                        "col": {
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "row": {
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "w": {
+                            "type": "integer",
+                            "minimum": 1
+                        },
+                        "h": {
+                            "type": "integer",
+                            "minimum": 1
+                        }
+                    }
+                },
+                "scaleW": {
+                    "type": "boolean",
+                    "description": "Hint: render-time scale width to fit content."
+                },
+                "scaleH": {
+                    "type": "boolean",
+                    "description": "Hint: render-time scale height to fit content (e.g. for repeatable freetext)."
+                },
+                "repeatable": {
+                    "type": "boolean",
+                    "description": "If true, fieldValues[key] is an array of primitives; otherwise a single primitive."
+                },
+                "renderOrder": {
+                    "type": "integer",
+                    "description": "Order in which this field's value(s) appear in the rendered shorthand text. Lower = earlier."
+                },
+                "ttsOrder": {
+                    "type": "integer",
+                    "description": "Order in which this field's value(s) are spoken via TTS. May differ from renderOrder."
+                },
+                "compact": {
+                    "type": "boolean",
+                    "description": "If true, no space is inserted between this field's tokens and adjacent compact tokens (matches the historic dir/sev/caution behaviour)."
+                },
+                "justify": {
+                    "type": "string",
+                    "enum": [
+                        "left",
+                        "center",
+                        "right"
+                    ],
+                    "description": "Text alignment of the rendered slot value."
+                },
+                "chips": {
+                    "type": "array",
+                    "description": "kind:'chips' only — the inline vocabulary for this field. Each chip is one allowed value.",
+                    "items": {
+                        "$ref": "#/definitions/chip"
+                    }
+                },
+                "min": {
+                    "type": "number",
+                    "description": "kind:'number' only — minimum value."
+                },
+                "max": {
+                    "type": "number",
+                    "description": "kind:'number' only — maximum value."
+                },
+                "step": {
+                    "type": "number",
+                    "description": "kind:'number' only — increment for scrollers / steppers."
+                },
+                "defaultValue": {
+                    "description": "kind:'number' only — initial value when the field is activated."
+                },
+                "numeric": {
+                    "type": "object",
+                    "description": "Optional augmentation for kind:'chips' fields — also exposes a numeric scroller alongside the chip grid. The value stored in fieldValues can be either a chip's value (string) or a number, whichever the user picked most recently.",
+                    "required": [
+                        "min",
+                        "max",
+                        "step"
+                    ],
+                    "properties": {
+                        "min": {
+                            "type": "number"
+                        },
+                        "max": {
+                            "type": "number"
+                        },
+                        "step": {
+                            "type": "number"
+                        },
+                        "defaultValue": {
+                            "type": "number"
+                        }
+                    }
+                },
+                "maxLines": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "kind:'freetext' only — soft cap on the number of lines rendered."
+                }
+            }
+        },
+        "chip": {
+            "type": "object",
+            "description": "One entry in a chips-kind field's vocabulary.",
+            "required": [
+                "value"
+            ],
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "description": "Canonical label stored on pace notes."
+                },
+                "audible": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "Optional TTS override if the spoken form differs from the label."
+                },
+                "angle": {
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "description": "Tilt angle in degrees, used by severity-like fields placed on a compass dial."
+                },
+                "textFormat": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Rendering hints (e.g. ['sub'] for subscript)."
+                }
+            }
+        }
+    },
+    "properties": {
+        "schemaVersion": {
+            "type": "integer",
+            "description": "Version of the field-config schema this document conforms to.",
+            "const": 1
+        },
+        "fields": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/field"
+            }
+        }
+    }
+}

--- a/field-config.schema.json
+++ b/field-config.schema.json
@@ -236,6 +236,13 @@
             "description": "Version of the field-config schema this document conforms to.",
             "const": 1
         },
+        "promptOrder": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "description": "Ordered list of field keys the recce UI's 'Next:' prompt strip cycles through. After each tap the strip advances to the next field in this list that is still empty on the current note. Fields not listed here are never auto-prompted (users can still tap their slot to edit). Optional — consumers may default to walking every chips-kind field by renderOrder when absent."
+        },
         "fields": {
             "type": "array",
             "items": {

--- a/field-config.schema.json
+++ b/field-config.schema.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft-07/schema#",
+    "$id": "https://raw.githubusercontent.com/Pylon-Motorsports/GRIP/main/field-config.schema.json",
     "title": "GripFieldConfig",
     "description": "Per-rally configuration of pace-note fields. Each rally defines which fields appear on a pacenote (name, kind, grid placement, render/TTS order, optional inline chip vocabulary). Pace notes then store their values as a JSON object keyed by field.key. Replaces the previous fixed-field model (direction / severity / duration / joiner / decorators / notes) so different rallies and disciplines can use entirely different shorthand systems.",
     "type": "object",
@@ -145,7 +146,54 @@
                     "minimum": 1,
                     "description": "kind:'freetext' only — soft cap on the number of lines rendered."
                 }
-            }
+            },
+            "allOf": [
+                {
+                    "if": {
+                        "required": ["kind"],
+                        "properties": { "kind": { "const": "chips" } }
+                    },
+                    "then": {
+                        "required": ["chips"],
+                        "properties": {
+                            "min": false,
+                            "max": false,
+                            "step": false,
+                            "defaultValue": false,
+                            "maxLines": false
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "required": ["kind"],
+                        "properties": { "kind": { "const": "number" } }
+                    },
+                    "then": {
+                        "properties": {
+                            "chips": false,
+                            "numeric": false,
+                            "maxLines": false
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "required": ["kind"],
+                        "properties": { "kind": { "const": "freetext" } }
+                    },
+                    "then": {
+                        "properties": {
+                            "chips": false,
+                            "min": false,
+                            "max": false,
+                            "step": false,
+                            "defaultValue": false,
+                            "numeric": false
+                        }
+                    }
+                }
+            ]
         },
         "chip": {
             "type": "object",

--- a/pace-note.schema.json
+++ b/pace-note.schema.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft-07/schema#",
+    "$id": "https://raw.githubusercontent.com/Pylon-Motorsports/GRIP/main/pace-note.schema.json",
     "title": "GripPaceNotes",
     "description": "A pace-note document covering one note set (one stage, one version). Storage-agnostic: use natural keys (rallyName + rallyDate + stageName + setVersion) for identity across parties; optional UUIDs are provided for implementations that need stable internal IDs. Pacenote field values are stored under each note's `fieldValues` object keyed by the field.key defined in the rally's accompanying field-config (see field-config.schema.json) — different rallies can use entirely different shorthand systems by shipping different field configs.",
     "type": "object",
@@ -153,8 +154,10 @@
             }
         },
         "fieldConfig": {
-            "description": "The rally's field-config inlined into the pace-note document so a consumer can render the notes without a separate file fetch. Shape matches field-config.schema.json (schemaVersion + fields).",
-            "type": "object"
+            "description": "The rally's field-config inlined into the pace-note document so a consumer can render the notes without a separate file fetch. When present, this inlined copy is authoritative for the document. Shape validates against field-config.schema.json.",
+            "allOf": [
+                { "$ref": "https://raw.githubusercontent.com/Pylon-Motorsports/GRIP/main/field-config.schema.json" }
+            ]
         },
         "notes": {
             "type": "array",

--- a/pace-note.schema.json
+++ b/pace-note.schema.json
@@ -1,12 +1,15 @@
 {
     "$schema": "https://json-schema.org/draft-07/schema#",
     "title": "GripPaceNotes",
-    "description": "A pace-note document covering one note set (one stage, one version). Storage-agnostic: use natural keys (rallyName + rallyDate + stageName + setVersion) for identity across parties; optional UUIDs are provided for implementations that need stable internal IDs.",
+    "description": "A pace-note document covering one note set (one stage, one version). Storage-agnostic: use natural keys (rallyName + rallyDate + stageName + setVersion) for identity across parties; optional UUIDs are provided for implementations that need stable internal IDs. Pacenote field values are stored under each note's `fieldValues` object keyed by the field.key defined in the rally's accompanying field-config (see field-config.schema.json) — different rallies can use entirely different shorthand systems by shipping different field configs.",
     "type": "object",
     "definitions": {
         "paceNote": {
             "type": "object",
-            "description": "A single pace-note call within a set.",
+            "description": "A single pace-note call within a set. Position/meta lives at the top level; the actual shorthand values live in fieldValues keyed by the rally's field-config keys.",
+            "required": [
+                "seq"
+            ],
             "properties": {
                 "seq": {
                     "type": "integer",
@@ -32,55 +35,25 @@
                         "null"
                     ]
                 },
-                "direction": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "severity": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "duration": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "decorators": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
+                "fieldValues": {
+                    "type": "object",
+                    "description": "Map of field.key → value. Values are primitives (string for chip selections / freetext / numeric-string distances, number for true numeric fields) or arrays of primitives when the field is repeatable. Field keys are defined by the accompanying field-config document.",
+                    "additionalProperties": {
+                        "oneOf": [
+                            { "type": "string" },
+                            { "type": "number" },
+                            { "type": "null" },
+                            {
+                                "type": "array",
+                                "items": {
+                                    "oneOf": [
+                                        { "type": "string" },
+                                        { "type": "number" }
+                                    ]
+                                }
+                            }
+                        ]
                     }
-                },
-                "joiner": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "joinerDecorators": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "notes": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "description": "Freetext annotation for the call."
-                },
-                "joinerNotes": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "description": "Freetext annotation for the joiner."
                 },
                 "recceAt": {
                     "type": [
@@ -96,66 +69,16 @@
                     ],
                     "format": "date-time"
                 }
-            },
-            "required": [
-                "seq"
-            ]
-        },
-        "chip": {
-            "type": "object",
-            "description": "One entry in a rally's chip vocabulary. Chips define the legal values for each pace-note field and optionally how they are rendered or spoken.",
-            "properties": {
-                "category": {
-                    "type": "string",
-                    "enum": [
-                        "direction",
-                        "severity",
-                        "duration",
-                        "joiner",
-                        "decorator",
-                        "caution_decorator",
-                        "joiner_decorator"
-                    ]
-                },
-                "value": {
-                    "type": "string",
-                    "description": "Canonical label stored on pace notes."
-                },
-                "audible": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "description": "Optional TTS override if the spoken form differs from the label."
-                },
-                "sortOrder": {
-                    "type": "integer",
-                    "minimum": 0
-                },
-                "angle": {
-                    "type": [
-                        "number",
-                        "null"
-                    ],
-                    "description": "Tilt angle in degrees for severity chips placed on a compass dial. Combined with car/course geometry this can be mapped to a turn radius."
-                },
-                "textFormat": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "description": "Rendering hints (e.g. 'sub' for subscript)."
-                }
-            },
-            "required": [
-                "category",
-                "value"
-            ]
+            }
         }
     },
     "properties": {
         "rally": {
             "type": "object",
+            "required": [
+                "name",
+                "date"
+            ],
             "properties": {
                 "name": {
                     "type": "string"
@@ -183,14 +106,13 @@
                     "format": "uuid",
                     "description": "Optional stable identifier for implementations that need it. Not required for exchange; natural keys are authoritative."
                 }
-            },
-            "required": [
-                "name",
-                "date"
-            ]
+            }
         },
         "stage": {
             "type": "object",
+            "required": [
+                "name"
+            ],
             "properties": {
                 "name": {
                     "type": "string"
@@ -199,13 +121,13 @@
                     "type": "string",
                     "format": "uuid"
                 }
-            },
-            "required": [
-                "name"
-            ]
+            }
         },
         "set": {
             "type": "object",
+            "required": [
+                "version"
+            ],
             "properties": {
                 "version": {
                     "type": "integer",
@@ -228,17 +150,11 @@
                     "type": "string",
                     "format": "uuid"
                 }
-            },
-            "required": [
-                "version"
-            ]
+            }
         },
-        "chips": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/chip"
-            },
-            "description": "Per-rally chip vocabulary. Needed for consistent rendering and TTS across devices."
+        "fieldConfig": {
+            "description": "The rally's field-config inlined into the pace-note document so a consumer can render the notes without a separate file fetch. Shape matches field-config.schema.json (schemaVersion + fields).",
+            "type": "object"
         },
         "notes": {
             "type": "array",

--- a/presets/classic-rally.field-config.json
+++ b/presets/classic-rally.field-config.json
@@ -1,5 +1,6 @@
 {
     "schemaVersion": 1,
+    "promptOrder": ["direction", "severity", "link"],
     "fields": [
         {
             "key": "caution",

--- a/presets/classic-rally.field-config.json
+++ b/presets/classic-rally.field-config.json
@@ -1,0 +1,138 @@
+{
+    "schemaVersion": 1,
+    "fields": [
+        {
+            "key": "caution",
+            "label": "Caution",
+            "kind": "chips",
+            "grid": { "col": 0, "row": 0, "w": 1, "h": 1 },
+            "renderOrder": 0,
+            "ttsOrder": 0,
+            "repeatable": true,
+            "compact": true,
+            "chips": [
+                { "value": "!" },
+                { "value": "!!" }
+            ]
+        },
+        {
+            "key": "direction",
+            "label": "Direction",
+            "kind": "chips",
+            "grid": { "col": 0, "row": 1, "w": 2, "h": 3 },
+            "renderOrder": 1,
+            "ttsOrder": 1,
+            "compact": true,
+            "justify": "center",
+            "chips": [
+                { "value": "L", "audible": "Left" },
+                { "value": "R", "audible": "Right" }
+            ]
+        },
+        {
+            "key": "severity",
+            "label": "Severity",
+            "kind": "chips",
+            "grid": { "col": 2, "row": 1, "w": 2, "h": 3 },
+            "renderOrder": 2,
+            "ttsOrder": 2,
+            "compact": true,
+            "justify": "center",
+            "chips": [
+                { "value": "1", "angle": 102, "textFormat": ["sub"] },
+                { "value": "2", "angle": 84,  "textFormat": ["sub"] },
+                { "value": "3", "angle": 66,  "textFormat": ["sub"] },
+                { "value": "4", "angle": 48,  "textFormat": ["sub"] },
+                { "value": "5", "angle": 30,  "textFormat": ["sub"] },
+                { "value": "6", "angle": 12,  "textFormat": ["sub"] }
+            ]
+        },
+        {
+            "key": "duration",
+            "label": "Duration",
+            "kind": "chips",
+            "grid": { "col": 4, "row": 1, "w": 1, "h": 3 },
+            "renderOrder": 3,
+            "ttsOrder": 3,
+            "compact": true,
+            "justify": "center",
+            "chips": [
+                { "value": "long" },
+                { "value": "short" }
+            ]
+        },
+        {
+            "key": "decorator",
+            "label": "Decorators",
+            "kind": "chips",
+            "grid": { "col": 0, "row": 4, "w": 5, "h": 1 },
+            "renderOrder": 4,
+            "ttsOrder": 4,
+            "repeatable": true,
+            "chips": [
+                { "value": "in" },
+                { "value": "out" },
+                { "value": "over" },
+                { "value": "keep" },
+                { "value": "maybe" },
+                { "value": "right" },
+                { "value": "left" },
+                { "value": "tighten" },
+                { "value": "open" },
+                { "value": "jump" },
+                { "value": "crest" },
+                { "value": "dip" },
+                { "value": "narrow" },
+                { "value": "wide" }
+            ]
+        },
+        {
+            "key": "link",
+            "label": "Link",
+            "kind": "chips",
+            "grid": { "col": 5, "row": 1, "w": 3, "h": 3 },
+            "renderOrder": 5,
+            "ttsOrder": 5,
+            "numeric": { "min": 10, "max": 900, "step": 10 },
+            "chips": [
+                { "value": "into" },
+                { "value": "and" },
+                { "value": "tightens" },
+                { "value": "opens" }
+            ]
+        },
+        {
+            "key": "linkDecorator",
+            "label": "Link Decorators",
+            "kind": "chips",
+            "grid": { "col": 5, "row": 0, "w": 3, "h": 1 },
+            "renderOrder": 6,
+            "ttsOrder": 6,
+            "repeatable": true,
+            "chips": [
+                { "value": "long" },
+                { "value": "short" },
+                { "value": "keep" },
+                { "value": "over" }
+            ]
+        },
+        {
+            "key": "notes",
+            "label": "Notes",
+            "kind": "freetext",
+            "grid": { "col": 0, "row": 5, "w": 5, "h": 2 },
+            "renderOrder": 7,
+            "ttsOrder": 7,
+            "maxLines": 3
+        },
+        {
+            "key": "linkNotes",
+            "label": "Link Notes",
+            "kind": "freetext",
+            "grid": { "col": 5, "row": 4, "w": 3, "h": 2 },
+            "renderOrder": 8,
+            "ttsOrder": 8,
+            "maxLines": 2
+        }
+    ]
+}


### PR DESCRIPTION
Replaces the fixed-field pace-note model with a user-defined field-config that lives per rally. Different rallies can now ship entirely different shorthand systems without forking the schema.

## Changes

**New: `field-config.schema.json`**

Each rally defines its own pace-note fields. Per field:
- \`key\` — stable identifier; pace notes reference it under \`fieldValues\`.
- \`label\` — UI display label.
- \`kind\` — \`chips\` | \`freetext\` | \`number\`.
- \`grid\` — \`col\` / \`row\` / \`w\` / \`h\` placement on the rally's input grid.
- \`repeatable\` — array vs single primitive in \`fieldValues\`.
- \`renderOrder\` / \`ttsOrder\` — token order in rendered shorthand vs TTS (can differ).
- \`compact\` — collapse inter-token space with adjacent compact fields.
- \`justify\` — text alignment of the rendered slot.
- For \`chips\` kind: inline \`chips\` vocabulary with per-chip \`audible\`, \`angle\`, \`textFormat\`.
- For \`number\` kind: \`min\`, \`max\`, \`step\`, \`defaultValue\`.
- For \`freetext\` kind: \`maxLines\`.
- Optional \`numeric\` augmentation on chips fields — also exposes a numeric scroller alongside the chip grid (e.g. a single \`link\` field that takes either \`→\` or a distance).

**Updated: `pace-note.schema.json`**

- Notes drop the eight fixed value columns (direction / severity / duration / joiner / decorators / joinerDecorators / notes / joinerNotes) and gain \`fieldValues\`: an object keyed by field.key.
- Values are primitives (string for chip selections / freetext / numeric-string distances, number for true numeric fields) or arrays of primitives for repeatable fields.
- Removes the top-level \`chips\` array. Replaced by an optional inlined \`fieldConfig\` object so consumers can render notes without a second fetch.

**Updated: README**

Sample updated to show field-config + fieldValues end-to-end.

## Companion implementation

[Pylon-Motorsports/GRIP-Note#24](https://github.com/Pylon-Motorsports/GRIP-Note/pull/24) implements this model in the GRIP-Note app — the renderer, RecceV2 grid screen, FieldEditor, and downstream surfaces (reading mode, PDF export, Drive) all consume field-config / fieldValues directly.

## Migration

Hard cut, matching the GRIP-Note app stance (Pylon-Motorsports/GRIP-Note#9): no users yet, no migration tooling, old documents won't parse against the new schema. If you need to keep older documents readable, pin them to a tagged release of the pre-split schema before merging this.